### PR TITLE
fix: use renovate pr automerge

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -7,6 +7,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   prettier-format-check:
     name: Format Check

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - renovate/**
   pull_request:
   workflow_dispatch:
 

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "description": "yodel's renovate config",
   "extends": ["config:best-practices"],
   "rangeStrategy": "widen",
-  "automergeType": "branch",
+  "automergeType": "pr",
   "semanticCommits": "enabled",
   "commitBodyTable": true,
   "assignees": ["SnakeDoc"],


### PR DESCRIPTION
prevents multiple ci runs triggered by renovate opening pr's after pushing to a branch